### PR TITLE
Fix tests for non-US machines

### DIFF
--- a/src/main/java/com/jitterted/mobreg/adapter/in/web/member/InProgressEnsembleView.java
+++ b/src/main/java/com/jitterted/mobreg/adapter/in/web/member/InProgressEnsembleView.java
@@ -8,6 +8,7 @@ import com.jitterted.mobreg.domain.MemberId;
 
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Stream;
 
 public record InProgressEnsembleView(String name,
@@ -26,7 +27,7 @@ public record InProgressEnsembleView(String name,
                                           ensemble.meetingLink().toString(),
                                           ensemble.startDateTime()
                                                   .toLocalTime()
-                                                  .format(DateTimeFormatter.ofPattern("hh:mm a")),
+                                                  .format(DateTimeFormatter.ofPattern("hh:mm a", Locale.US)),
                                           "/member/timer-view/" + ensembleId.id(),
                                           ensembleTimerHolder.hasTimerFor(ensembleId),
                                           namesOf(ensemble.participants(), memberService),

--- a/src/main/java/com/jitterted/mobreg/adapter/out/email/EmailNotifier.java
+++ b/src/main/java/com/jitterted/mobreg/adapter/out/email/EmailNotifier.java
@@ -15,14 +15,15 @@ import java.net.URI;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Locale;
 
 @Primary
 @Component
 public class EmailNotifier implements Notifier {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(EmailNotifier.class);
-    private static final DateTimeFormatter LONG_DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("LLLL d, uuuu 'at' h:mma (zzz)");
-    private static final DateTimeFormatter SHORT_DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd 'at' h:mma (zzz)");
+    private static final DateTimeFormatter LONG_DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("LLLL d, uuuu 'at' h:mma (zzz)", Locale.US);
+    private static final DateTimeFormatter SHORT_DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd 'at' h:mma (zzz)", Locale.US);
 
     private final MemberService memberService;
     private final Emailer emailer;

--- a/src/main/java/com/jitterted/mobreg/adapter/out/websocket/TimerToHtmlTransformer.java
+++ b/src/main/java/com/jitterted/mobreg/adapter/out/websocket/TimerToHtmlTransformer.java
@@ -8,6 +8,7 @@ import com.jitterted.mobreg.domain.TimeRemaining;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Collectors;
 
 public class TimerToHtmlTransformer {
@@ -111,23 +112,25 @@ public class TimerToHtmlTransformer {
     // language=html
     private static String htmlForTimerContainer(TimeRemaining timeRemaining, String cssState) {
         double percentRemaining = timeRemaining.percent();
-        return """
-               <div id="timer-container"
-                    class="circle circle-%s"
-                    style="background: conic-gradient(%s 0%% %f%%, black %f%% 100%%);">
-                   <svg class="progress-ring">
-                       <circle class="progress-circle"/>
-                   </svg>
-                   <div class="timer-text-container timer-%s">
-                       <div class="timer-text">%d:%02d</div>
-                   </div>
-               </div>
-               """.formatted(cssState,
-                             cssState.equals("running") ? "lightgreen" : "#FFD033",
-                             percentRemaining, percentRemaining,
-                             cssState,
-                             timeRemaining.minutes(),
-                             timeRemaining.seconds());
+        String template = """
+                <div id="timer-container"
+                     class="circle circle-%s"
+                     style="background: conic-gradient(%s 0%% %f%%, black %f%% 100%%);">
+                    <svg class="progress-ring">
+                        <circle class="progress-circle"/>
+                    </svg>
+                    <div class="timer-text-container timer-%s">
+                        <div class="timer-text">%d:%02d</div>
+                    </div>
+                </div>
+                """;
+        return String.format(Locale.ROOT, template,
+                cssState,
+                cssState.equals("running") ? "lightgreen" : "#FFD033",
+                percentRemaining, percentRemaining,
+                cssState,
+                timeRemaining.minutes(),
+                timeRemaining.seconds());
     }
 
     // language=html


### PR DESCRIPTION
Some tests failed on my machine, because they are assuming the current locale to be `Locale.US`, but my machine has a different locale.

I added explicit locale arguments to some string formatters to fix the tests.