### PR TITLE
Synching Timers to Conductor via PUT call

### DIFF
--- a/src/main/java/com/jitterted/mobreg/adapter/in/web/member/InProgressEnsembleView.java
+++ b/src/main/java/com/jitterted/mobreg/adapter/in/web/member/InProgressEnsembleView.java
@@ -8,6 +8,7 @@ import com.jitterted.mobreg.domain.MemberId;
 
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Stream;
 
 public record InProgressEnsembleView(String name,
@@ -26,7 +27,7 @@ public record InProgressEnsembleView(String name,
                                           ensemble.meetingLink().toString(),
                                           ensemble.startDateTime()
                                                   .toLocalTime()
-                                                  .format(DateTimeFormatter.ofPattern("hh:mm a")),
+                                                  .format(DateTimeFormatter.ofPattern("hh:mm a", Locale.US)),
                                           "/member/timer-view/" + ensembleId.id(),
                                           ensembleTimerHolder.hasTimerFor(ensembleId),
                                           namesOf(ensemble.participants(), memberService),

--- a/src/main/java/com/jitterted/mobreg/adapter/out/conductor/SyncConductorTimerRequest.java
+++ b/src/main/java/com/jitterted/mobreg/adapter/out/conductor/SyncConductorTimerRequest.java
@@ -1,0 +1,42 @@
+package com.jitterted.mobreg.adapter.out.conductor;
+
+import com.jitterted.mobreg.domain.CountdownTimer;
+import com.jitterted.mobreg.domain.EnsembleTimer;
+import com.jitterted.mobreg.domain.Member;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+record SyncConductorTimerRequest(
+        int timeRemainingSeconds,
+        String state,
+        String driver,
+        String navigator,
+        String nextDriver,
+        List<String> restOfParticipants) {
+
+    public static SyncConductorTimerRequest from(EnsembleTimer timer) {
+        return new SyncConductorTimerRequest(
+                timer.timeRemaining().minutes() * 60 +
+                timer.timeRemaining().seconds(),
+                mapTimerState(timer.state()),
+                timer.rotation().driver().firstName(),
+                timer.rotation().navigator().firstName(),
+                timer.rotation().nextDriver().firstName(),
+                timer.rotation().restOfParticipants().stream()
+                        .map(Member::firstName)
+                        .toList()
+        );
+    }
+
+    @NotNull
+    private static String mapTimerState(CountdownTimer.TimerState state) {
+        return switch (state) {
+            case WAITING_TO_START -> "Waiting";
+            case RUNNING -> "Running";
+            case PAUSED -> "Paused";
+            case FINISHED -> "Finished";
+        };
+    }
+
+}

--- a/src/main/java/com/jitterted/mobreg/adapter/out/email/EmailNotifier.java
+++ b/src/main/java/com/jitterted/mobreg/adapter/out/email/EmailNotifier.java
@@ -15,14 +15,15 @@ import java.net.URI;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Locale;
 
 @Primary
 @Component
 public class EmailNotifier implements Notifier {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(EmailNotifier.class);
-    private static final DateTimeFormatter LONG_DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("LLLL d, uuuu 'at' h:mma (zzz)");
-    private static final DateTimeFormatter SHORT_DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd 'at' h:mma (zzz)");
+    private static final DateTimeFormatter LONG_DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("LLLL d, uuuu 'at' h:mma (zzz)", Locale.US);
+    private static final DateTimeFormatter SHORT_DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd 'at' h:mma (zzz)", Locale.US);
 
     private final MemberService memberService;
     private final Emailer emailer;

--- a/src/main/java/com/jitterted/mobreg/adapter/out/websocket/TimerToHtmlTransformer.java
+++ b/src/main/java/com/jitterted/mobreg/adapter/out/websocket/TimerToHtmlTransformer.java
@@ -8,6 +8,7 @@ import com.jitterted.mobreg.domain.TimeRemaining;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Collectors;
 
 public class TimerToHtmlTransformer {
@@ -111,23 +112,25 @@ public class TimerToHtmlTransformer {
     // language=html
     private static String htmlForTimerContainer(TimeRemaining timeRemaining, String cssState) {
         double percentRemaining = timeRemaining.percent();
-        return """
-               <div id="timer-container"
-                    class="circle circle-%s"
-                    style="background: conic-gradient(%s 0%% %f%%, black %f%% 100%%);">
-                   <svg class="progress-ring">
-                       <circle class="progress-circle"/>
-                   </svg>
-                   <div class="timer-text-container timer-%s">
-                       <div class="timer-text">%d:%02d</div>
-                   </div>
-               </div>
-               """.formatted(cssState,
-                             cssState.equals("running") ? "lightgreen" : "#FFD033",
-                             percentRemaining, percentRemaining,
-                             cssState,
-                             timeRemaining.minutes(),
-                             timeRemaining.seconds());
+        String template = """
+                <div id="timer-container"
+                     class="circle circle-%s"
+                     style="background: conic-gradient(%s 0%% %f%%, black %f%% 100%%);">
+                    <svg class="progress-ring">
+                        <circle class="progress-circle"/>
+                    </svg>
+                    <div class="timer-text-container timer-%s">
+                        <div class="timer-text">%d:%02d</div>
+                    </div>
+                </div>
+                """;
+        return String.format(Locale.ROOT, template,
+                cssState,
+                cssState.equals("running") ? "lightgreen" : "#FFD033",
+                percentRemaining, percentRemaining,
+                cssState,
+                timeRemaining.minutes(),
+                timeRemaining.seconds());
     }
 
     // language=html

--- a/src/test/java/com/jitterted/mobreg/adapter/out/conductor/SyncConductorTimerRequestTest.java
+++ b/src/test/java/com/jitterted/mobreg/adapter/out/conductor/SyncConductorTimerRequestTest.java
@@ -1,0 +1,121 @@
+package com.jitterted.mobreg.adapter.out.conductor;
+
+import com.jitterted.mobreg.domain.EnsembleId;
+import com.jitterted.mobreg.domain.EnsembleTimer;
+import com.jitterted.mobreg.domain.EnsembleTimerFactory;
+import com.jitterted.mobreg.domain.Member;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SyncConductorTimerRequestTest {
+
+    private static final EnsembleId IRRELEVANT_ENSEMBLE_ID = EnsembleId.of(42);
+    private static final String IRRELEVANT_ENSEMBLE_NAME = "My Ensemble";
+
+    @Nested
+    class TimerState {
+        @Test
+        void waitingTimerIsMappedToConductorStateWaiting() {
+            EnsembleTimer timer = EnsembleTimerFactory.createTimer();
+
+            SyncConductorTimerRequest request = SyncConductorTimerRequest.from(timer);
+
+            assertThat(request.state())
+                    .isEqualTo("Waiting");
+        }
+
+        @Test
+        void runningTimerIsMappedToConductorStateRunning() {
+            EnsembleTimer timer = EnsembleTimerFactory.createTimer();
+            Instant startedAt = Instant.now();
+            timer.startTimerAt(startedAt);
+            timer.tick(startedAt.plusSeconds(10));
+
+            SyncConductorTimerRequest request = SyncConductorTimerRequest.from(timer);
+
+            assertThat(request.state())
+                    .isEqualTo("Running");
+        }
+
+        @Test
+        void pausedTimerIsMappedToConductorStatePaused() {
+            EnsembleTimer timer = EnsembleTimerFactory.createTimer();
+            timer.startTimerAt(Instant.now());
+            timer.pause();
+
+            SyncConductorTimerRequest request = SyncConductorTimerRequest.from(timer);
+
+            assertThat(request.state())
+                    .isEqualTo("Paused");
+        }
+
+        @Test
+        void finishedTimerIsMappedToConductorStateFinished() {
+            EnsembleTimer timer = EnsembleTimerFactory
+                    .create4MinuteTimerInFinishedState()
+                    .ensembleTimer();
+
+            SyncConductorTimerRequest request = SyncConductorTimerRequest.from(timer);
+
+            assertThat(request.state())
+                    .isEqualTo("Finished");
+        }
+    }
+
+    @Nested
+    class RemainingTime {
+        @Test
+        void waitingTimerHasFullDurationRemaining() {
+            var timer = EnsembleTimerFactory.createTimerWith4MinuteDuration();
+
+            SyncConductorTimerRequest request = SyncConductorTimerRequest.from(timer);
+
+            assertThat(request.timeRemainingSeconds())
+                    .isEqualTo(4 * 60);
+        }
+
+        @Test
+        void runningTimeHasTimeRemainingInSeconds() {
+            var timer = EnsembleTimerFactory.createTimerWith4MinuteDuration();
+            Instant startedAt = Instant.now();
+            timer.startTimerAt(startedAt);
+            timer.tick(startedAt.plusSeconds(15));
+
+            SyncConductorTimerRequest request = SyncConductorTimerRequest.from(timer);
+
+            assertThat(request.timeRemainingSeconds())
+                    .isEqualTo(4 * 60 - 15);
+        }
+    }
+
+    @Test
+    void rotationIsMappedToRequestParts() {
+        EnsembleTimer timer = new EnsembleTimer(
+                IRRELEVANT_ENSEMBLE_ID,
+                IRRELEVANT_ENSEMBLE_NAME,
+                List.of(
+                        new Member("Alex", "alex_github"),
+                        new Member("Berta", "berta_github"),
+                        new Member("Chloe", "chloe_github"),
+                        new Member("David", "david_github"),
+                        new Member("Erika", "erika_github")
+                ));
+
+        SyncConductorTimerRequest request = SyncConductorTimerRequest.from(timer);
+
+        assertThat(request.navigator())
+                .isEqualTo("Chloe");
+        assertThat(request.driver())
+                .isEqualTo("Berta");
+        assertThat(request.nextDriver())
+                .isEqualTo("Alex");
+        assertThat(request.restOfParticipants())
+                .containsExactly("David", "Erika");
+    }
+
+}


### PR DESCRIPTION
The `conductor` _Outbound Adapter_ now contains a transformer to convert an `EnsembleTimer` to the representation understood by Conductor:

```json
{
    "state": "Running",
    "timeRemainingSeconds": 109,
    "driver": "Driver",
    "navigator": "Navigator",
    "nextDriver": "Next Driver",
    "restOfParticipants": [
        "Amy",
        "Barbara"
    ]
}
```

The `ConductorHttpBroadcaster` now sends PUT calls for any timer change to the Conductor backend.

I've change the names of the sent timer to include the prefix `"Ensembler - "`.

This PR builds on the changes made in PR #217 for fixing test running on my local machine.